### PR TITLE
user multiarch image as base image.

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,6 +1,5 @@
 # Copyright Contributors to the Open Cluster Management project
-
-FROM openshift/origin-release:golang-1.13 AS builder
+FROM registry.ci.openshift.org/open-cluster-management/builder:go1.15-linux AS builder
 
 ENV GOFLAGS="-mod=vendor"
 COPY . /go/src/github.com/open-cluster-management/metrics-collector


### PR DESCRIPTION
ref: open-cluster-management/backlog#11324