### PR TITLE
remove resource setting for simulatedd metric-collector.

### DIFF
--- a/test/simulator/setup-metrics-collector.sh
+++ b/test/simulator/setup-metrics-collector.sh
@@ -72,6 +72,7 @@ do
 	cat "$deploy_yaml_file" | kubectl -n ${cluster_name} apply -f -
 	rm -rf "$deploy_yaml_file" "$deploy_yaml_file".tmp
 	kubectl -n ${cluster_name} patch deploy metrics-collector-deployment --type='json' -p='[{"op": "replace", "path": "/metadata/ownerReferences", "value": []}]'
+	kubectl -n ${cluster_name} patch deploy metrics-collector-deployment --type='json' -p='[{"op": "remove", "path": "/spec/template/spec/containers/0/resources"}]'
 
 	# deploy ClusterRoleBinding for read metrics from OCP prometheus
 	rolebinding_yaml_file=${cluster_name}-metrics-collector-view.yaml


### PR DESCRIPTION
Not sure if this makes sense or not, but if I want to start up more simulated metric collectors, I need to remove the resource setting from the simulated metrics collectors.

Signed-off-by: morvencao <lcao@redhat.com>